### PR TITLE
Update for 2021

### DIFF
--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -1,0 +1,46 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Pytest workflow
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Setup Java JDK 1.8
+      uses: actions/setup-java@v1.4.3
+      with:
+            java-version: '1.8' # The JDK version to make available on the path.
+            java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
+            architecture: x64 # (x64 or x86) - defaults to x64
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pyspark pytest
+    - name: Retrieve template test cases
+      run: |
+        git remote add upstream https://github.com/tgteacher/BigData-LA4.git
+        git fetch upstream master
+        git checkout upstream/master -- tests
+    - name: Test with pytest
+      env: 
+        PYTHONHASHSEED: 0
+        PYTHONPATH: $PWD/answers
+      run: |
+        PYTHONPATH=$PWD/answers pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os: linux
 language: python
 
 python:
-    - "3.5"
+    - "3.6"
 env:
 - ASSIGNMENT_REPO=https://github.com/tgteacher/BigData-LA4.git PYTHONHASHSEED=0 PYTHONPATH=$PYTHONPATH:$PWD/answers JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
@@ -12,7 +12,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install openjdk-8-jdk
   - sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
-  - pip install pyspark pytest "dask[complete]" scipy
+  - pip install pyspark pytest scipy
   # The two lines below ensure that everybody will run the same tests in
   # case they are updated
   - \mv -f tests tests.old

--- a/answers/answer.py
+++ b/answers/answer.py
@@ -211,8 +211,8 @@ def hash_bands(data_file, seed, n_b, n_r):
        is a pair.
     2. groups the resulting RDD by key: states that hash to the same bucket for
        band b will appear together.
-    3. returns the string output of the buckets with more than 2 elements
-       using the function in pretty_print_bands.py.
+    3. Return a dictionnary where the key is the band b, and the value is a list
+       of buckets with more than 2 elements.
 
     That's it, you have printed the similar items, in O(n)!
 

--- a/tests/test_hash_bands.py
+++ b/tests/test_hash_bands.py
@@ -2,6 +2,28 @@ import sys
 sys.path.insert(0, './answers')
 from answer import hash_bands
 
+def compare(r1, r2):
+    if len(r1) != len(r2):
+        print(str(len(r1)) + " - " + str(len(r2)))
+    assert(len(r1) == len(r2))
+    for i in range(len(r1)):
+        list_found = False
+        for j in range(len(r2)):
+            res_list = r1[i]
+            a_list = r2[j]
+            if res_list == a_list:
+                list_found = True
+                break
+        if not list_found:
+            print(r2[j])
+        assert(list_found)
+    return True
 def test_hash_bands():
+    res = {0: [['oh','on','qc'], ['ga','nc','sc','tn'], ['nf','ns'], ['ct','nj']],
+    1: [['md','nj','pa','va'], ['on','qc'], ['nb','ns'], ['id','mt'], ['ia','mn'], ['mi','oh','wv'], ['ar','la'], ['il','mo','wi'],['nc','tn'], ['ne','sd'], ['ct','ma','me','nh','ny']],
+    2: [['nb','qc'], ['md','pa','sc','va'], ['ak','yt'], ['id','wa'], ['de','nj','ri'], ['me','nh'], ['ar','tn'], ['il','nc']],
+    3: [['tn','va'], ['ar','ms'], ['al','ga','ky','sc'], ['il','mo'], ['ct','ma','nh'], ['on','qc'], ['mt','wy'], ['mn','wi'], ['me','nb']],
+    4: [['ma','tn','va','wv'], ['nt','yt'], ['nb','ns']]}
     out = hash_bands("./data/plants.data", 123, 5, 7)
-    assert(out==open("tests/test-hash-bands.txt","r").read())
+    for i in range(5):
+        compare(res[i], out[i])


### PR DESCRIPTION
Update Travis file for python 3.6.
Add GitHub action.

Modify the last test so it doesn't use the value of the bucket. Therefore, instead of comparing two strings, I compare the bands that are a list of buckets. With the bucket being just a list of states. The comparison between two bands is made by using the same function as in LA3, 'compare' in tests/test_kmeans.py. That way, the hash value of the bucket is not used and the order does not depend on this value, thus the python version or anything that influences the built-in function hash.